### PR TITLE
Pass `--timestamping` to GeoIP db download 

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,6 +7,7 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
+echo "       Starting the Heroku Buildpack Geoip from Easol"
 # see https://devcenter.heroku.com/articles/buildpack-api - during compilation
 # app env vars exist only as files within the ENV_VAR directory
 if [[ -s "$ENV_DIR/MAXMIND_LICENSE_KEY" ]]

--- a/bin/compile
+++ b/bin/compile
@@ -43,12 +43,13 @@ mkdir -p "$LIBMAXMINDDB_CACHE_DIST_DIR"
 echo "       Downloading GeoLite2 City and Country data"
 
 # see https://dev.maxmind.com/geoip/geoipupdate/ (Direct Downloads version)
-wget --quiet --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_CITY_TARBALL_FILENAME" \
+wget --quiet --timestamping --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_CITY_TARBALL_FILENAME" \
      "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=$MAXMIND_LICENSE_KEY&suffix=tar.gz"
 
-wget --quiet --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_COUNTRY_TARBALL_FILENAME" \
+wget --quiet --timestamping --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_COUNTRY_TARBALL_FILENAME" \
      "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=$MAXMIND_LICENSE_KEY&suffix=tar.gz"
 
+ls -a "$GEOIP_CACHE_DIR"
 echo "       Unzipping GeoLite2 City and Country data"
 
 tar -xvf "$GEOIP_CACHE_DIR/$GEOLITE2_CITY_TARBALL_FILENAME" --directory "$BUILD_DIST_SHARE_DIR" --no-anchored --strip-components=1 "$GEOLITE2_CITY_FILENAME"


### PR DESCRIPTION
This should ensure wget caches the result preventing downloading the Db
too often and hittin our download limits.

It only download it again when the file is new.