### PR TITLE
Use `--no-clobber` instead of `--timestamping`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -43,10 +43,10 @@ mkdir -p "$LIBMAXMINDDB_CACHE_DIST_DIR"
 echo "       Downloading GeoLite2 City and Country data"
 
 # see https://dev.maxmind.com/geoip/geoipupdate/ (Direct Downloads version)
-wget --quiet --timestamping --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_CITY_TARBALL_FILENAME" \
+wget --quiet --no-clobber --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_CITY_TARBALL_FILENAME" \
      "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=$MAXMIND_LICENSE_KEY&suffix=tar.gz"
 
-wget --quiet --timestamping --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_COUNTRY_TARBALL_FILENAME" \
+wget --quiet --no-clobber --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_COUNTRY_TARBALL_FILENAME" \
      "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=$MAXMIND_LICENSE_KEY&suffix=tar.gz"
 
 ls -a "$GEOIP_CACHE_DIR"


### PR DESCRIPTION
Looks like `timestamping` isn't preventing downloading again or that rate limiting doesn't even allow the request to be processed.

The `no-clobber` skip downloads that would download to existing files.