### PR TITLE
Only download the geoip database once per day

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -28,7 +28,10 @@ GEOLITE2_COUNTRY_TARBALL_FILENAME="GeoLite2-Country.tar.gz"
 BUILD_DIST_DIR="$BUILD_DIR/.geoip"
 BUILD_DIST_SHARE_DIR="$BUILD_DIST_DIR/share"
 
+DATE=$(date +%Y%m%d)
+
 GEOIP_CACHE_DIR="$CACHE_DIR/geoip"
+GEOIP_CACHE_VERSION_FILE="${GEOIP_CACHE_DIR}/last_downloaded"
 LIBMAXMINDDB_CACHE_DIR="$GEOIP_CACHE_DIR/libmaxminddb"
 LIBMAXMINDDB_CACHE_DIST_DIR="$GEOIP_CACHE_DIR/libmaxminddb/dist"
 LIBMAXMINDDB_CACHE_VERSION_FILE="$LIBMAXMINDDB_CACHE_DIR/libmaxminddb-version"
@@ -42,16 +45,23 @@ mkdir -p "$LIBMAXMINDDB_CACHE_DIST_DIR"
 
 echo "       Downloading GeoLite2 City and Country data"
 
-ls -al "$GEOIP_CACHE_DIR"
+if [ "$(cat ${GEOIP_CACHE_VERSION_FILE} 2>/dev/null)" != "${DATE}" ]; then
+  curl -z ${GEOIP_CACHE_DIR}/${GEOLITE2_COUNTRY_TARBALL_FILENAME} -o ${GEOLITE2_COUNTRY_TARBALL_FILENAME} \
+    "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=$MAXMIND_LICENSE_KEY&suffix=tar.gz"
 
-# see https://dev.maxmind.com/geoip/geoipupdate/ (Direct Downloads version)
-wget --verbose --no-clobber --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_CITY_TARBALL_FILENAME" \
-     "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=$MAXMIND_LICENSE_KEY&suffix=tar.gz" || true
+  if [ -f "${GEOLITE2_COUNTRY_TARBALL_FILENAME}" ]; then
+    mv ${GEOLITE2_COUNTRY_TARBALL_FILENAME} ${GEOIP_CACHE_DIR}/${GEOLITE2_COUNTRY_TARBALL_FILENAME}
+  fi
 
-wget --verbose --no-clobber --output-document "$GEOIP_CACHE_DIR/$GEOLITE2_COUNTRY_TARBALL_FILENAME" \
-     "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=$MAXMIND_LICENSE_KEY&suffix=tar.gz" || true
+  curl -z ${GEOIP_CACHE_DIR}/${GEOLITE2_CITY_TARBALL_FILENAME} -o ${GEOLITE2_CITY_TARBALL_FILENAME} \
+    "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=$MAXMIND_LICENSE_KEY&suffix=tar.gz"
 
-ls -al "$GEOIP_CACHE_DIR"
+  if [ -f "${GEOLITE2_CITY_TARBALL_FILENAME}" ]; then
+    mv ${GEOLITE2_CITY_TARBALL_FILENAME} ${GEOIP_CACHE_DIR}/${GEOLITE2_CITY_TARBALL_FILENAME}
+  fi
+
+  echo ${DATE} > ${GEOIP_CACHE_VERSION_FILE}
+fi
 
 echo "       Unzipping GeoLite2 City and Country data"
 


### PR DESCRIPTION
We've also switched to curl instead of wget so we will only download the databases if they've changed compared to the versions we have.

Even with the If-Modified-Since header, we can still be rate limited, so we do also need the logic to only download once per day.

(wget has a --timestamping option, but it does not work if you also set the name of the file you're downloading, so we get a filename with all the query params present).

I'm comparing the timestamp and writing the file to different places, and then moving the downloaded file. This is in case curl tries to write the new file before reading the old timestamp. I wasn't able to verify if was the case or not.